### PR TITLE
Use script properties for Dropea token

### DIFF
--- a/COD_Manager_Dropea.js
+++ b/COD_Manager_Dropea.js
@@ -105,7 +105,7 @@ function actualizarPedidosDesdeDropea() {
 
 // Función para obtener pedidos de Dropea API
 function obtenerPedidosDropea() {
-  const TOKEN = 'AIza0g6jlFCN1vqnxCPj1Pr0-qgmIG2HNIgZcFiF6C522IQ=';
+  const token = PropertiesService.getScriptProperties().getProperty('DROPEA_API_KEY');
   
   try {
     Logger.log('📡 Consultando pedidos desde Dropea API...');
@@ -129,7 +129,7 @@ function obtenerPedidosDropea() {
     const options = {
       method: 'POST',
       headers: {
-        'X-api-key': TOKEN,
+        'X-api-key': token,
         'Content-Type': 'application/json'
       },
       payload: JSON.stringify({ query: query })

--- a/Dropea_Update.js
+++ b/Dropea_Update.js
@@ -7,12 +7,14 @@
 /**
  * CONFIGURACIÓN
  */
+const SCRIPT_PROPERTIES = PropertiesService.getScriptProperties();
 const DROPEA_CONFIG = {
-  API_URL: 'https://api.dropea.com/graphql/dropshippers',
-  API_KEY: 'AIzaejsD46ULeywoDCvhFgWGOYvRkokx03l3NDeohz2wCo8=',
+  API_URL: SCRIPT_PROPERTIES.getProperty('DROPEA_API_URL') ||
+    'https://api.dropea.com/graphql/dropshippers',
+  API_KEY: SCRIPT_PROPERTIES.getProperty('DROPEA_API_KEY'),
   HEADERS: {
     'Content-Type': 'application/json',
-    'x-api-key': 'AIzaejsD46ULeywoDCvhFgWGOYvRkokx03l3NDeohz2wCo8='
+    'x-api-key': SCRIPT_PROPERTIES.getProperty('DROPEA_API_KEY')
   }
 };
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# COD Manager - Dropea Integration
+
+This project synchronizes orders with the Dropea API. The API key is no longer hard-coded in the code. Instead, it is read from **Script Properties** in your Apps Script project.
+
+## Setting the Script Properties
+1. Open the project in the Google Apps Script editor.
+2. Choose **File → Project properties** and open the **Script Properties** tab.
+3. Create the following keys and paste your values:
+   - `DROPEA_API_KEY` – Dropea API token.
+   - `DROPEA_API_URL` – optional custom endpoint. If not set, the default endpoint `https://api.dropea.com/graphql/dropshippers` is used.
+4. Save the properties and redeploy the project if necessary.
+
+Once these properties are set, the scripts `Dropea_Update.js` and `COD_Manager_Dropea.js` will automatically read the token and endpoint from the script properties.


### PR DESCRIPTION
## Summary
- load Dropea API key and URL from Apps Script properties
- document how to configure these script properties

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68467941f4ec832cbb2439ae5a4c9364