### PR TITLE
Extend Dropea order state handling

### DIFF
--- a/Dropea_Update.js
+++ b/Dropea_Update.js
@@ -24,13 +24,17 @@ const DROPEA_CONFIG = {
 const MAPEO_ESTADOS = {
   'DELIVERED': 'Entregado',
   'CHARGED': 'Entregado',
-  'REJECTED': 'Devolucion', 
+  'REJECTED': 'Devolucion',
   'CANCELLED': 'Devolucion',
+  'RETURNED': 'Devolucion',
   'TRANSIT': 'En tránsito',
   'PREPARED': 'En tránsito',
   'INCIDENCE': 'INCIDENCIA',
   'PENDING': 'En tránsito'
 };
+
+// Estado a usar cuando se recibe un valor desconocido desde Dropea
+const ESTADO_DESCONOCIDO = 'INCIDENCIA';
 
 /**
  * FUNCIÓN PRINCIPAL - Actualizar desde Dropea
@@ -165,11 +169,10 @@ function procesarCambios(pedidosPendientes, estadosDropea) {
     }
     
     // Mapear estado de Dropea a nuestro sistema
-    const nuevoEstado = MAPEO_ESTADOS[estadoDropea];
-    
-    if (!nuevoEstado) {
-      Logger.log(`⚠️ Estado ${estadoDropea} no mapeado para pedido ${pedido.id}`);
-      continue;
+    const nuevoEstado = MAPEO_ESTADOS[estadoDropea] || ESTADO_DESCONOCIDO;
+
+    if (!MAPEO_ESTADOS[estadoDropea]) {
+      Logger.log(`⚠️ Estado ${estadoDropea} no mapeado para pedido ${pedido.id}, usando ${ESTADO_DESCONOCIDO}`);
     }
     
     // Solo actualizar si hay cambio real

--- a/README.md
+++ b/README.md
@@ -11,3 +11,17 @@ This project synchronizes orders with the Dropea API. The API key is no longer h
 4. Save the properties and redeploy the project if necessary.
 
 Once these properties are set, the scripts `Dropea_Update.js` and `COD_Manager_Dropea.js` will automatically read the token and endpoint from the script properties.
+
+## Order State Mapping
+
+`Dropea_Update.js` contains a mapping from Dropea's `OrderStateEnum` to the
+values used in the spreadsheet. The main states are:
+
+| Dropea state | Sheet value |
+|--------------|-------------|
+| `DELIVERED`, `CHARGED` | `Entregado` |
+| `REJECTED`, `CANCELLED`, `RETURNED` | `Devolucion` |
+| `TRANSIT`, `PREPARED`, `PENDING` | `En tránsito` |
+| `INCIDENCE` | `INCIDENCIA` |
+
+Any unrecognized state falls back to `INCIDENCIA` and a warning is logged.


### PR DESCRIPTION
## Summary
- handle additional Dropea order states
- log and fallback to `INCIDENCIA` when state is unknown
- document Dropea order state mapping

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68474c17dc34832cae1dd31c9236be0b