### PR TITLE
Switch to HTTPS for ip-api lookups

### DIFF
--- a/Fraud_Detection.js
+++ b/Fraud_Detection.js
@@ -196,7 +196,7 @@ function extraerInfoPedido(datosQ) {
 function analizarGeolocalizacion(ip, provinciaEntrega, ciudadEntrega) {
   try {
     // Usar API gratuita de ip-api.com (1000 consultas/mes)
-    const url = `http://ip-api.com/json/${ip}?fields=status,country,regionName,region,city&lang=es`;
+    const url = `https://ip-api.com/json/${ip}?fields=status,country,regionName,region,city&lang=es`;
     const response = UrlFetchApp.fetch(url);
     const data = JSON.parse(response.getContentText());
     

--- a/Utilities.js
+++ b/Utilities.js
@@ -319,7 +319,7 @@ function consultarIPConCache(ip) {
     }
     
     // Si no está en cache, hacer consulta nueva
-    const url = `http://ip-api.com/json/${ip}?fields=status,country,regionName,region,city&lang=es`;
+    const url = `https://ip-api.com/json/${ip}?fields=status,country,regionName,region,city&lang=es`;
     const response = UrlFetchApp.fetch(url);
     const data = JSON.parse(response.getContentText());
     


### PR DESCRIPTION
## Summary
- use HTTPS for IP geolocation API in Fraud_Detection.js
- use HTTPS for IP geolocation API in Utilities.js

## Testing
- `node test_cache.js` (checks caching behaviour)
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68474c322548832c803fe91601773593