### PR TITLE
Use configurable pause for fraud checks

### DIFF
--- a/Fraud_Detection.js
+++ b/Fraud_Detection.js
@@ -35,7 +35,12 @@ function analizarNuevosPedidos() {
         }
         
         // Pausa pequeña para evitar límites de la API
-        Utilities.sleep(100);
+        const pausa =
+          (typeof FRAUD_CONFIG !== 'undefined' &&
+            FRAUD_CONFIG.analisis &&
+            FRAUD_CONFIG.analisis.pausaEntreConsultas) ||
+          100;
+        Utilities.sleep(pausa);
       }
     }
     
@@ -83,7 +88,12 @@ function reAnalizarTodosPedidos() {
         }
         
         // Pausa para evitar límites de API
-        Utilities.sleep(100);
+        const pausa =
+          (typeof FRAUD_CONFIG !== 'undefined' &&
+            FRAUD_CONFIG.analisis &&
+            FRAUD_CONFIG.analisis.pausaEntreConsultas) ||
+          100;
+        Utilities.sleep(pausa);
       }
     }
     

--- a/WebApp_Interface.js
+++ b/WebApp_Interface.js
@@ -141,7 +141,12 @@ function ejecutarAnalisisAntifraude() {
           sospechosos++;
         }
         
-        Utilities.sleep(100);
+        const pausa =
+          (typeof FRAUD_CONFIG !== 'undefined' &&
+            FRAUD_CONFIG.analisis &&
+            FRAUD_CONFIG.analisis.pausaEntreConsultas) ||
+          100;
+        Utilities.sleep(pausa);
       }
     }
     


### PR DESCRIPTION
## Summary
- read pause duration from `FRAUD_CONFIG.analisis.pausaEntreConsultas`
- fall back to 100 ms if configuration is missing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68474c57f904832cbdb4132826cacee5