### PR TITLE
Expose shared column config

### DIFF
--- a/COD_Manager.js
+++ b/COD_Manager.js
@@ -56,14 +56,8 @@ function actualizarPedidos() {
     const { hojaOrders, hojaWorksheet, datosOrders, datosWorksheet } = validarDatosCompletos();
     const cambios = [];
     
-    // Mapeo de columnas
-    const colOrders = {
-      id: 4,        // E - ID del pedido
-      nombre: 5,    // F - Nombre del cliente
-      telefono: 6,  // G - Teléfono
-      estado: 15,   // P - Estado del pedido
-      fecha: 3      // D - Fecha del pedido
-    };
+    // Mapeo de columnas tomado de la configuración central
+    const colOrders = obtenerColumnasOrders();
     
     const colWorksheet = {
       id: 1,        // B - ID del pedido con formato

--- a/COD_Manager_Dropea.js
+++ b/COD_Manager_Dropea.js
@@ -27,14 +27,8 @@ function actualizarPedidosDesdeDropea() {
     
     const cambios = [];
     
-    // Mapeo de columnas (igual que tu función original)
-    const colOrders = {
-      id: 4,        // E - ID del pedido (Shopify)
-      nombre: 5,    // F - Nombre del cliente
-      telefono: 6,  // G - Teléfono
-      estado: 15,   // P - Estado del pedido
-      fecha: 3      // D - Fecha del pedido
-    };
+    // Mapeo de columnas tomado de la configuración central
+    const colOrders = obtenerColumnasOrders();
     
     // Procesar cada pedido de Dropea
     for (let pedidoDropea of pedidosDropea) {

--- a/Config.js
+++ b/Config.js
@@ -324,6 +324,13 @@ function obtenerMapaProvincias() {
 }
 
 /**
+ * Devuelve el mapeo de columnas para la hoja ORDERS
+ */
+function obtenerColumnasOrders() {
+  return CONFIG.columnas.orders;
+}
+
+/**
  * Obtiene configuración de una sección específica
  */
 function obtenerConfigSeccion(seccion) {


### PR DESCRIPTION
## Summary
- add `obtenerColumnasOrders` helper in `Config.js`
- use shared configuration in `COD_Manager.js`
- use shared configuration in `COD_Manager_Dropea.js`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68474c69fee0832c8afdbc646c7c198c