### PR TITLE
Add bot log infrastructure

### DIFF
--- a/Bot_Automation.js
+++ b/Bot_Automation.js
@@ -1,0 +1,54 @@
+// ===================================================================
+// BOT AUTOMATION UTILITIES
+// ===================================================================
+// Archivo: Bot_Automation.gs
+// Descripción: Envío y actualización de mensajes mediante Telegram Bot
+// ===================================================================
+
+const BOT_TOKEN = PropertiesService.getScriptProperties().getProperty('TELEGRAM_BOT_TOKEN');
+
+function enviarMensajeBot(chatId, mensaje) {
+  if (!BOT_TOKEN) {
+    Logger.log('Token de bot no configurado');
+    return null;
+  }
+
+  const url = `https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`;
+  const options = {
+    method: 'post',
+    contentType: 'application/json',
+    payload: JSON.stringify({ chat_id: chatId, text: mensaje })
+  };
+
+  try {
+    const response = UrlFetchApp.fetch(url, options);
+    logBotMensaje(chatId, mensaje);
+    return JSON.parse(response.getContentText());
+  } catch (error) {
+    logBotActualizacion(chatId, `Error enviando mensaje: ${error}`);
+    return null;
+  }
+}
+
+function actualizarMensajeBot(chatId, messageId, nuevoTexto) {
+  if (!BOT_TOKEN) {
+    Logger.log('Token de bot no configurado');
+    return null;
+  }
+
+  const url = `https://api.telegram.org/bot${BOT_TOKEN}/editMessageText`;
+  const options = {
+    method: 'post',
+    contentType: 'application/json',
+    payload: JSON.stringify({ chat_id: chatId, message_id: messageId, text: nuevoTexto })
+  };
+
+  try {
+    const response = UrlFetchApp.fetch(url, options);
+    logBotActualizacion(chatId, `edit ${messageId}: ${nuevoTexto}`);
+    return JSON.parse(response.getContentText());
+  } catch (error) {
+    logBotActualizacion(chatId, `Error editando mensaje: ${error}`);
+    return null;
+  }
+}

--- a/Config.js
+++ b/Config.js
@@ -210,7 +210,8 @@ const LOG_CONFIG = {
   
   hojas: {
     actualizaciones: 'LOG_ACTUALIZACIONES',
-    antifraude: 'LOG_ANTIFRAUDE'
+    antifraude: 'LOG_ANTIFRAUDE',
+    bot: 'LOG_BOT'
   },
   
   encabezados: {
@@ -219,14 +220,18 @@ const LOG_CONFIG = {
       'Estado Anterior', 'Estado Nuevo', 'Usuario', 'Observaciones'
     ],
     antifraude: [
-      'Fecha/Hora', 'Tipo Análisis', 'Pedidos Analizados', 
+      'Fecha/Hora', 'Tipo Análisis', 'Pedidos Analizados',
       'Sospechosos Detectados', 'Tasa Detección', 'Usuario'
+    ],
+    bot: [
+      'Fecha/Hora', 'Evento', 'Detalle', 'Usuario'
     ]
   },
   
   colores: {
     encabezados: '#f1f3f4',
-    encabezadosAntifraude: '#fff3e0'
+    encabezadosAntifraude: '#fff3e0',
+    encabezadosBot: '#e8eaf6'
   },
   
   retencion: {

--- a/Utilities.js
+++ b/Utilities.js
@@ -191,6 +191,40 @@ function crearLogAntifraude(analisisRealizados, sospechososDetectados) {
   }
 }
 
+function crearLogBot(evento, detalle) {
+  try {
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+    let hojaLogBot = ss.getSheetByName('LOG_BOT');
+
+    if (!hojaLogBot) {
+      hojaLogBot = ss.insertSheet('LOG_BOT');
+      hojaLogBot.getRange(1, 1, 1, 4).setValues([
+        ['Fecha/Hora', 'Evento', 'Detalle', 'Usuario']
+      ]);
+      const headerRange = hojaLogBot.getRange(1, 1, 1, 4);
+      headerRange.setBackground('#e8eaf6');
+      headerRange.setFontWeight('bold');
+    }
+
+    const timestamp = new Date();
+    const usuario = Session.getActiveUser().getEmail();
+    const nuevaFila = [timestamp, evento, detalle || 'N/A', usuario];
+    const ultimaFila = hojaLogBot.getLastRow();
+    hojaLogBot.getRange(ultimaFila + 1, 1, 1, 4).setValues([nuevaFila]);
+
+  } catch (error) {
+    Logger.log('Error al crear log bot: ' + error.toString());
+  }
+}
+
+function logBotMensaje(chatId, mensaje) {
+  crearLogBot('MENSAJE', `Chat ${chatId}: ${mensaje}`);
+}
+
+function logBotActualizacion(chatId, descripcion) {
+  crearLogBot('ACTUALIZACION', `Chat ${chatId}: ${descripcion}`);
+}
+
 // ==== FUNCIONES DE FECHA Y TIEMPO ====
 
 function obtenerFechaHoy() {


### PR DESCRIPTION
## Summary
- add `LOG_BOT` settings in `Config.js`
- log bot messages and updates through new helpers
- create helper to send bot messages and record events

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68474c885440832c8d0613e4a161e74d