### PR TITLE
Switch geolocation API to HTTPS

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -159,7 +159,7 @@ const FRAUD_CONFIG = {
   apis: {
     geolocalizacion: {
       proveedor: 'ip-api.com',
-      url: 'http://ip-api.com/json/',
+      url: 'https://ip-api.com/json/',
       camposConsulta: 'status,country,regionName,region,city',
       idioma: 'es',
       limiteMensual: 1000,


### PR DESCRIPTION
## Summary
- use `https://ip-api.com/json/` in `FRAUD_CONFIG`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6847de80aa18832c92d5995377d55d04