### PR TITLE
Use caching for IP geolocation

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -163,7 +163,8 @@ const FRAUD_CONFIG = {
       camposConsulta: 'status,country,regionName,region,city',
       idioma: 'es',
       limiteMensual: 1000,
-      cacheDuracion: 86400 // 24 horas en segundos
+      // Duración del cache de resultados de geolocalización
+      cacheDuracion: 172800 // 48 horas en segundos
     }
   }
 };

--- a/Fraud_Detection.js
+++ b/Fraud_Detection.js
@@ -198,10 +198,8 @@ function extraerInfoPedido(datosQ) {
 
 function analizarGeolocalizacion(ip, provinciaEntrega, ciudadEntrega, config) {
   try {
-    // Construir URL de consulta usando la configuración
-    const url = `${config.apis.geolocalizacion.url}${ip}?fields=${config.apis.geolocalizacion.camposConsulta}&lang=${config.apis.geolocalizacion.idioma}`;
-    const response = UrlFetchApp.fetch(url, { muteHttpExceptions: true, timeout: config.analisis.timeoutAPI });
-    const data = JSON.parse(response.getContentText());
+    // Consultar la IP utilizando cache para evitar llamadas repetidas
+    const data = consultarIPConCache(ip);
     
     if (data.status !== 'success') {
       return { puntos: config.puntuaciones.ipNoLocalizable, detalle: 'IP no localizable' };


### PR DESCRIPTION
## Summary
- consult cached IP data in `analizarGeolocalizacion`
- set geo lookup cache duration to 48 hours

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847de8bbfa0832c86dc54cf059a8b20